### PR TITLE
chore: update rust_sdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 near-sdk = { version = "5.1.0", features = ["unstable"] }
 
 [dev-dependencies]
-near-sdk = { version = "5.0.0", features = ["unit-testing"] }
+near-sdk = { version = "5.1.0", features = ["unit-testing"] }
 near-workspaces = { version = "0.10.0", features = ["unstable"] }
 tokio = { version = "1.12.0", features = ["full"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "rlib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-near-sdk = { version = "5.0.0", features = ["unstable"] }
+near-sdk = { version = "5.1.0", features = ["unstable"] }
 
 [dev-dependencies]
 near-sdk = { version = "5.0.0", features = ["unit-testing"] }

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -1,5 +1,5 @@
 use near_sdk::serde::Serialize;
-use near_sdk::{env, log, near_bindgen, AccountId, NearToken, Promise, PromiseError, PublicKey};
+use near_sdk::{env, log, near, AccountId, NearToken, Promise, PromiseError, PublicKey};
 
 use crate::{Contract, ContractExt, NEAR_PER_STORAGE, NO_DEPOSIT, TGAS};
 
@@ -9,7 +9,7 @@ struct DonationInitArgs {
     beneficiary: AccountId,
 }
 
-#[near_bindgen]
+#[near]
 impl Contract {
     #[payable]
     pub fn create_factory_subaccount_and_deploy(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 // Find all our documentation at https://docs.near.org
-use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::store::LazyOption;
-use near_sdk::{near_bindgen, Gas, NearToken};
+use near_sdk::{near, Gas, NearToken};
 
 mod deploy;
 mod manager;
@@ -12,9 +11,7 @@ const TGAS: Gas = Gas::from_tgas(1); // 10e12yⓃ
 const NO_DEPOSIT: NearToken = NearToken::from_near(0); // 0yⓃ
 
 // Define the contract structure
-#[near_bindgen]
-#[derive(BorshDeserialize, BorshSerialize)]
-#[borsh(crate = "near_sdk::borsh")]
+#[near(contract_state)]
 pub struct Contract {
     // Since a contract is something big to store, we use LazyOptions
     // this way it is not deserialized on each method call

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,8 +1,8 @@
-use near_sdk::{env, near_bindgen};
+use near_sdk::{env, near};
 
 use crate::{Contract, ContractExt};
 
-#[near_bindgen]
+#[near]
 impl Contract {
     #[private]
     pub fn update_stored_contract(&mut self) {


### PR DESCRIPTION
updates rust sdk to 5.1 making use of #[near] and #[near(contract_state)]