### PR TITLE
Fix contract 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ crate-type = ["cdylib", "rlib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-near-sdk = { version = "5.1.0", features = ["unstable"] }
+near-sdk = { version = "5.3.0", features = ["unstable"] }
 
 [dev-dependencies]
-near-sdk = { version = "5.1.0", features = ["unit-testing"] }
+near-sdk = { version = "5.3.0", features = ["unit-testing"] }
 near-workspaces = { version = "0.10.0", features = ["unstable"] }
 tokio = { version = "1.12.0", features = ["full"] }
 serde_json = "1"

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -1,5 +1,5 @@
 use near_sdk::serde::Serialize;
-use near_sdk::{env, log, near, AccountId, NearToken, Promise, PromiseError, PublicKey, require};
+use near_sdk::{env, log, near, AccountId, NearToken, Promise, PromiseError, PublicKey};
 
 use crate::{Contract, ContractExt, NEAR_PER_STORAGE, NO_DEPOSIT, TGAS};
 
@@ -21,7 +21,7 @@ impl Contract {
         // Assert the sub-account is valid
         let current_account = env::current_account_id().to_string();
         let subaccount: AccountId = format!("{name}.{current_account}").parse().unwrap();
-        require!(
+        assert!(
             env::is_valid_account_id(subaccount.as_bytes()),
             "Invalid subaccount"
         );
@@ -34,9 +34,9 @@ impl Contract {
         let contract_storage_cost = NEAR_PER_STORAGE.saturating_mul(contract_bytes);
         // Require a little more since storage cost is not exact
         let minimum_needed = contract_storage_cost.saturating_add(NearToken::from_millinear(100));
-        require!(
+        assert!(
             attached >= minimum_needed,
-            "Attach at least {minimum_needed} yⓃ",
+            "Attach at least {minimum_needed} yⓃ"
         );
 
         let init_args = near_sdk::serde_json::to_vec(&DonationInitArgs { beneficiary }).unwrap();

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -1,5 +1,5 @@
 use near_sdk::serde::Serialize;
-use near_sdk::{env, log, near, AccountId, NearToken, Promise, PromiseError, PublicKey};
+use near_sdk::{env, log, near, AccountId, NearToken, Promise, PromiseError, PublicKey, require};
 
 use crate::{Contract, ContractExt, NEAR_PER_STORAGE, NO_DEPOSIT, TGAS};
 
@@ -21,7 +21,7 @@ impl Contract {
         // Assert the sub-account is valid
         let current_account = env::current_account_id().to_string();
         let subaccount: AccountId = format!("{name}.{current_account}").parse().unwrap();
-        assert!(
+        require!(
             env::is_valid_account_id(subaccount.as_bytes()),
             "Invalid subaccount"
         );
@@ -31,10 +31,12 @@ impl Contract {
 
         let code = self.code.clone().unwrap();
         let contract_bytes = code.len() as u128;
-        let minimum_needed = NEAR_PER_STORAGE.saturating_mul(contract_bytes);
-        assert!(
+        let contract_storage_cost = NEAR_PER_STORAGE.saturating_mul(contract_bytes);
+        // Require a little more since storage cost is not exact
+        let minimum_needed = contract_storage_cost.saturating_add(NearToken::from_millinear(100));
+        require!(
             attached >= minimum_needed,
-            "Attach at least {minimum_needed} yⓃ"
+            "Attach at least {minimum_needed} yⓃ",
         );
 
         let init_args = near_sdk::serde_json::to_vec(&DonationInitArgs { beneficiary }).unwrap();

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -74,13 +74,11 @@ impl Contract {
         #[callback_result] create_deploy_result: Result<(), PromiseError>,
     ) -> bool {
         if let Ok(_result) = create_deploy_result {
-            log!(format!("Correctly created and deployed to {account}"));
+            log!("Correctly created and deployed to {account}");
             return true;
         };
 
-        log!(format!(
-            "Error creating {account}, returning {attached}yⓃ to {user}"
-        ));
+        log!("Error creating {account}, returning {attached}yⓃ to {user}");
         Promise::new(user).transfer(attached);
         false
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,9 @@ use near_sdk::{near, Gas, NearToken};
 mod deploy;
 mod manager;
 
-const NEAR_PER_STORAGE: NearToken = NearToken::from_yoctonear(10u128.pow(18)); // 10e18yⓃ
+const NEAR_PER_STORAGE: NearToken = NearToken::from_yoctonear(10u128.pow(19)); // 10e19yⓃ
 const DEFAULT_CONTRACT: &[u8] = include_bytes!("./donation-contract/donation.wasm");
-const TGAS: Gas = Gas::from_tgas(1); // 10e12yⓃ
+const TGAS: Gas = Gas::from_tgas(1);
 const NO_DEPOSIT: NearToken = NearToken::from_near(0); // 0yⓃ
 
 // Define the contract structure


### PR DESCRIPTION
- Fix deposit amount, previously it was a factor of 10 smaller 
- Fix tests 
- Update sdk version to 5.3.0 
- Add extra test to check can't deploy with less than required.

Unsure why creating the subaccount and deploying code to it costs a little more than expected (calculated storage cost 1.54905 NEAR, it needs 0.00198 NEAR more). This additional cost is likley the storage used up on init. I just required 0.1 extra NEAR.